### PR TITLE
remove useless sleep

### DIFF
--- a/cleanip.py
+++ b/cleanip.py
@@ -121,7 +121,6 @@ async def main():
                     print(f"Failed to terminate process {e}")
                     xray.kill()  # Kill process if termination fail
     
-            await sleep(0.1)
     except KeyboardInterrupt:
         print("\nScript interrupted! Saving progress...")
 


### PR DESCRIPTION
as i tested this sleep `await sleep(0.1)` only makes script slower
but using this
```
        xray.terminate()
        await xray.wait()
```
  should makes enough waiting , so i think there is no point to use an extra sleep